### PR TITLE
fix: Server Status is null

### DIFF
--- a/src/UserClient/Server.ts
+++ b/src/UserClient/Server.ts
@@ -64,7 +64,10 @@ export class Server implements ServerAttributes {
     readonly allocations: number;
     readonly backups: number;
   };
-  status: ServerStatus | null;
+  /**
+   * @deprecated Use getStatus() or getUsage() instead, as the panel will always return null as status
+   */
+  status: null;
   readonly is_suspended: boolean;
   readonly is_installing: boolean;
   readonly is_transferring: boolean;
@@ -107,6 +110,13 @@ export class Server implements ServerAttributes {
    */
   public async getConsoleSocket(prettyLogs: boolean = true): Promise<ServerConsoleConnection> {
     return new ServerConsoleConnection(this, client, prettyLogs);
+  }
+
+  /**
+   * Get the status of this server
+   */
+  public async getStatus(): Promise<ServerStatus> {
+    return (await this.getUsage()).current_state;
   }
 
   /**

--- a/src/UserClient/Server.ts
+++ b/src/UserClient/Server.ts
@@ -123,8 +123,7 @@ export class Server implements ServerAttributes {
    * Get the server resource usage
    */
   public async getUsage(): Promise<StatsAttributes> {
-    const endpoint = new URL(client.panel + '/api/client/servers/' + this.identifier + '/resources');
-    return ((await client.api({ url: endpoint.href })) as RawStats).attributes;
+    return await client.getServerUsage(this.identifier);
   }
 
   /**

--- a/src/UserClient/Server.ts
+++ b/src/UserClient/Server.ts
@@ -116,7 +116,7 @@ export class Server implements ServerAttributes {
    * Get the status of this server
    */
   public async getStatus(): Promise<ServerStatus> {
-    return (await this.getUsage()).current_state;
+    return await client.getServerStatus(this.identifier);
   }
 
   /**

--- a/src/UserClient/UserClient.ts
+++ b/src/UserClient/UserClient.ts
@@ -1,5 +1,6 @@
 import { BaseClient, ClientOptions } from '../BaseClient/BaseClient';
 import { RawServer, RawServerList } from '../types/user/server';
+import { RawStats, StatsAttributes } from '../types/user/stats';
 import { RawUser } from '../types/user/user';
 import { Server } from './Server';
 import { User } from './User';
@@ -31,5 +32,13 @@ export class UserClient extends BaseClient {
   public async getServer(id: string): Promise<Server> {
     const endpoint = new URL(this.panel + '/api/client/servers/' + id);
     return new Server(this, (await this.api({ url: endpoint.href })) as RawServer);
+  }
+
+  /**
+   * Get the usage for a specific server
+   */
+  public async getServerUsage(id: string): Promise<StatsAttributes> {
+    const endpoint = new URL(this.panel + '/api/client/servers/' + id + '/resources');
+    return ((await this.api({ url: endpoint.href })) as RawStats).attributes;
   }
 }

--- a/src/UserClient/UserClient.ts
+++ b/src/UserClient/UserClient.ts
@@ -1,4 +1,5 @@
 import { BaseClient, ClientOptions } from '../BaseClient/BaseClient';
+import { ServerStatus } from '../types/base/serverStatus';
 import { RawServer, RawServerList } from '../types/user/server';
 import { RawStats, StatsAttributes } from '../types/user/stats';
 import { RawUser } from '../types/user/user';
@@ -40,5 +41,12 @@ export class UserClient extends BaseClient {
   public async getServerUsage(id: string): Promise<StatsAttributes> {
     const endpoint = new URL(this.panel + '/api/client/servers/' + id + '/resources');
     return ((await this.api({ url: endpoint.href })) as RawStats).attributes;
+  }
+
+  /**
+   * Get the status of a specific server
+   */
+  public async getServerStatus(id: string): Promise<ServerStatus> {
+    return (await this.getServerUsage(id)).current_state;
   }
 }

--- a/src/types/user/server.ts
+++ b/src/types/user/server.ts
@@ -44,7 +44,7 @@ export interface ServerAttributes {
     readonly allocations: number;
     readonly backups: number;
   };
-  status: null | ServerStatus;
+  status: null;
   readonly is_suspended: boolean;
   readonly is_installing: boolean;
   readonly is_transferring: boolean;


### PR DESCRIPTION
The panel returns null as server status instead of the actual status.   
You can now fetch the status via `server.getStatus()` in addition to `server.getUsage()`.  
A deprecation warning was added to the useless property.