### PR TITLE
fix: Serverstate is running instead of online

### DIFF
--- a/src/types/base/serverStatus.ts
+++ b/src/types/base/serverStatus.ts
@@ -1,4 +1,4 @@
-export type ServerStatus = 'starting' | 'stopping' | 'online' | 'offline';
+export type ServerStatus = 'starting' | 'stopping' | 'running' | 'offline';
 
 export enum SERVER_SIGNAL {
   'START' = 'start',


### PR DESCRIPTION
ServerStatus has been updated to include 'running' instead of 'online' to match the response from the panel

fixes #104 