### PR TITLE
fixed the server delete route

### DIFF
--- a/src/ApplicationClient/PanelServer.ts
+++ b/src/ApplicationClient/PanelServer.ts
@@ -632,7 +632,7 @@ export class PanelServer implements ServerAttributes {
    */
   public async delete(force: boolean = false): Promise<void> {
     // deepcode ignore AmbiguousConditional
-    const endpoint = new URL(client.panel + '/api/application/servers/' + this.id + force ? '/force' : '/');
+    const endpoint = new URL(client.panel + '/api/application/servers/' + this.id + (force ? '/force' : '/'));
     await client.api({ url: endpoint.href, method: 'DELETE' });
   }
 


### PR DESCRIPTION
The delete server path doesn't work as the
```ts
client.panel + '/api/application/servers/' + this.id + force ? '/force' : '/'
```
will always return an invalid url. Fixed it by wrapping `+ force ? '/force' : '/'` in ()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where deleting a server could use an incorrect URL, ensuring the correct endpoint is used when performing server deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->